### PR TITLE
WIP: fix build with OpenSSL 3

### DIFF
--- a/src/update_engine/omaha_hash_calculator.cc
+++ b/src/update_engine/omaha_hash_calculator.cc
@@ -52,8 +52,16 @@ class ScopedBioHandle {
 };
 
 OmahaHashCalculator::OmahaHashCalculator() : valid_(false) {
-  valid_ = (SHA256_Init(&ctx_) == 1);
-  LOG_IF(ERROR, !valid_) << "SHA256_Init failed";
+  ctx_ = EVP_MD_CTX_create();
+  valid_ = ctx_ != NULL;
+  LOG_IF(ERROR, !valid_) << "EVP_MD_CTX_create() returned NULL";
+  if (!valid_)
+    return;
+
+  valid_ = EVP_DigestInit_ex(ctx_, EVP_sha256(), NULL) == 1;
+  LOG_IF(ERROR, !valid_) << "EVP_DigestInit_ex() failed";
+  if (!valid_)
+    EVP_MD_CTX_free(ctx_);
 }
 
 // Update is called with all of the data that should be hashed in order.
@@ -63,7 +71,7 @@ bool OmahaHashCalculator::Update(const char* data, size_t length) {
   TEST_AND_RETURN_FALSE(hash_.empty());
   static_assert(sizeof(size_t) <= sizeof(unsigned long),
                 "length param may be truncated in SHA256_Update");
-  TEST_AND_RETURN_FALSE(SHA256_Update(&ctx_, data, length) == 1);
+  TEST_AND_RETURN_FALSE(EVP_DigestUpdate(ctx_, data, length) == 1);
   return true;
 }
 
@@ -168,12 +176,14 @@ bool OmahaHashCalculator::Base64Decode(const string& raw_in,
 // Call Finalize() when all data has been passed in. This mostly just
 // calls OpenSSL's SHA256_Final() and then base64 encodes the hash.
 bool OmahaHashCalculator::Finalize() {
+  unsigned int hash_size = EVP_MD_size(EVP_sha256());
+
   TEST_AND_RETURN_FALSE(hash_.empty());
   TEST_AND_RETURN_FALSE(raw_hash_.empty());
-  raw_hash_.resize(SHA256_DIGEST_LENGTH);
+  raw_hash_.resize(hash_size);
   TEST_AND_RETURN_FALSE(
-      SHA256_Final(reinterpret_cast<unsigned char*>(&raw_hash_[0]),
-                   &ctx_) == 1);
+    EVP_DigestFinal_ex(ctx_,
+      reinterpret_cast<unsigned char*>(&raw_hash_[0]), &hash_size) == 1);
 
   // Convert raw_hash_ to base64 encoding and store it in hash_.
   return Base64Encode(&raw_hash_[0], raw_hash_.size(), &hash_);

--- a/src/update_engine/omaha_hash_calculator.h
+++ b/src/update_engine/omaha_hash_calculator.h
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include <glog/logging.h>
-#include <openssl/sha.h>
+#include <openssl/evp.h>
 
 #include "macros.h"
 
@@ -94,7 +94,7 @@ class OmahaHashCalculator {
   bool valid_;
 
   // The hash state used by OpenSSL
-  SHA256_CTX ctx_;
+  EVP_MD_CTX *ctx_;
   DISALLOW_COPY_AND_ASSIGN(OmahaHashCalculator);
 };
 


### PR DESCRIPTION
update_engine has historically used the low-level OpenSSL hashing and RSA signature APIs, which have been deprecated in version 3. This PR migrates to the higher-level EVP APIs.

## Testing done

Unit tests don't pass. `PayloadSigner` isn't returning the expected test vector. We may be using the wrong API for decrypting the RSA signature.
