### PR TITLE
workflow: Update actions/checkout to v3

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install deps
       run: |
         sudo apt update && sudo apt install -y libunwind-dev && sudo apt install -y libblkid-dev libext2fs-dev libmount-dev curl unzip libdbus-glib-1-dev protobuf-compiler libbz2-dev libgflags-dev libssl-dev libgoogle-glog-dev libcurl4-openssl-dev libxml2-dev libprotobuf-dev cmake wget libtool autoconf libgtest-dev libgmock-dev libbrotli-dev libdivsufsort-dev libsodium-dev


### PR DESCRIPTION
This avoids a warning about using deprecated features.