### PR TITLE
flatcar-postinst: Clean up incomplete move target

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -158,6 +158,7 @@ if [ "${OEMID}" != "" ] && { [ -e "${INSTALL_MNT}/share/flatcar/oems/${OEMID}" ]
     # We don't need to check if it's the initial MVP OEM because it's an update payload provided for a particular version
     echo "Trying to place /var/lib/update_engine/oem-${OEMID}-${NEXT_VERSION}.raw on OEM partition" >&2
     if ! mv "/var/lib/update_engine/oem-${OEMID}.raw" "${NEW_SYSEXT}"; then
+        rm -f "${NEW_SYSEXT}"
         echo "That failed, moving it to right location on root partition" >&2
         NEW_SYSEXT="/etc/flatcar/oem-sysext/oem-${OEMID}-${NEXT_VERSION}.raw"
         mv "/var/lib/update_engine/oem-${OEMID}.raw" "${NEW_SYSEXT}"


### PR DESCRIPTION
When the old OEM contents and a yet inactive systemd-sysext image are on the OEM partition (or if no two sysexts fit on it), it can fail to write the second systemd-sysext image on the OEM partition and the rootfs is used instead. However, "mv" doesn't clean up the incomplete target file which filled the disk, this results in the migration flag file creation to fail, which fails the update action.
Clean up the incomplete move target that filled the disk.

## How to use

Backport to Alpha/Beta because this fixes the problem of not being able to update from ≤ 3619.0.0

## Testing done

in https://github.com/flatcar/scripts/pull/1272
