### PR TITLE
decode_payload: Skip over signature entries that cause errors

### DIFF
--- a/decode_payload
+++ b/decode_payload
@@ -142,7 +142,7 @@ while IFS= read -r LINE; do
   "data:"*)
             SIGDATA=$(echo "${LINE}" | cut -d '"' -f 2- | head -c-2 | sed 's/%/%%/g')
             # This is a workaround for the dev-key vs prod-key case: sed '/signatures {/d' | sed '/  version: 2/d'
-            SIGHEX=$(printf -- "${SIGDATA}" | sed '/signatures {/d' | sed '/  version: 2/d' | openssl rsautl -verify -pubin -inkey "${PUBKEY}" -raw | tail -c 32 | od -An -vtx1  -w1024 | tr -d ' ')
+            SIGHEX=$(printf -- "${SIGDATA}" | sed '/signatures {/d' | sed '/  version: 2/d' | openssl rsautl -verify -pubin -inkey "${PUBKEY}" -raw | tail -c 32 | od -An -vtx1  -w1024 | tr -d ' ' || true)
             # The raw output instead of asn1parse is used to easily extract the sha256 checksum (done by tail -c 32)
             # We also calculate the payload hash that the signature was done for, note that it's of course not the whole file but only up to the attached signature itself
             PAYLOADHASH=$(head -c "$((20 + MLEN + SIGOFFSET))" "${FILE}" | sha256sum | cut -d ' ' -f 1)


### PR DESCRIPTION
Either the printf escaping gives wrong binary data or the random dummy key signature is really broken for the oem-ami.gz 3745.1.0 amd64 payload.
The error reported is:
RSA operation error
007E9295D47F0000:error:02000084:rsa routines:rsa_ossl_public_decrypt:data too large for modulus:crypto/rsa/rsa_ossl.c:661: 007E9295D47F0000:error:1C880004:Provider routines:rsa_verify_recover:RSA lib:providers/implementations/signature/rsa_sig.c:748:

## How to use

Backport to Beta

## Testing done

```
wget -O /var/tmp/oem-ami.gz https://update.release.flatcar-linux.net/amd64-usr/3745.1.0/oem-ami.gz
PROTOPATH=src/update_engine/ ./decode_payload ~/flatcar/scripts/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-au-key/files/official-v2.pub.pem /var/tmp/oem-ami.gz /var/tmp/out
```