### PR TITLE
flatcar-postinst: Ensure /etc/extensions is mergable

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -217,6 +217,18 @@ for NAME in $(grep -h -o '^[^#]*' /etc/flatcar/enabled-sysext.conf /usr/share/fl
     mv  "/var/lib/update_engine/flatcar-${NAME}.raw" "/etc/flatcar/sysext/flatcar-${NAME}-${NEXT_VERSION}.raw"
 done
 
+# A mkdir -p /etc/extensions was done for the OEM sysext symlink when the /etc overlay
+# was already set up but we didn't ship /etc/extensions in the lowerdir. Since overlayfs
+# creates any folders that don't exist in the lowerdir as opaque it means that when
+# they appear later in the lowerdir through an update, the lowerdir folder is ignored.
+# That happened in the update from, e.g., 3760.1.0 to 3794.0.0 to where /etc/extensions
+# wasn't present in /usr/share/flatcar/etc/.
+# To fix this, remove any opaque markers for this directory. Other common folders which
+# we introduce later in the lowerdir could also be handled that way, e.g., /etc/cni/.
+if mountpoint -q /etc; then
+  unshare -m sh -c "umount /etc && mkdir -p /etc/extensions && attr -R -r overlay.opaque /etc/extensions || true"
+fi
+
 # Keep old nodes on cgroup v1
 if [[ "${BUILD_ID}" != "dev-"* ]]; then
     if [ "${VERSION_ID%%.*}" -lt 2956 ]; then


### PR DESCRIPTION
In Beta 3760.1.0 the /etc/extensions/ folder gets created by "mkdir -p" because it does not exist in the lowerdir /usr/share/flatcar/etc/. This causes the opaque marker to be set by overlayfs. The update to Alpha thus does not merge the new /usr/share/flatcar/etc/extensions/ folder with its docker/containerd sysext symlinks. We should have had /etc/extensions/ in the lowerdir in Beta but didn't.

Ensure that the created folders are mergable by removing the overlayfs marker. This is needed for existing installations and folders we expect to exist in the lowerdir but were missing so far.

## How to use

Backport to Alpha and Beta

## Testing done

Update from Beta to this here with `sudo flatcar-update -D -V 1.2.3 -E flatcar_test_update-oem-qemu.gz -P flatcar_test_update.gz` and after the reboot the extension folder has all contents.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
