### PR TITLE
Only store Omaha XML response for update check

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -135,7 +135,7 @@ if [ "${OEMID}" != "" ] && { [ -e "${INSTALL_MNT}/share/flatcar/oems/${OEMID}" ]
     # which only works with a new update-engine client that creates "full-response",
     # and we also have to check that this file was created fresh for this update operation
     # (relies on the reset of /var/lib/update_engine/prefs/previous-version that old clients also do)
-    if [ -e /var/lib/update_engine/prefs/full-response ] && [ $(stat -L --printf='%Y' /var/lib/update_engine/prefs/full-response) -gt $(stat -L --printf='%Y' /var/lib/update_engine/prefs/previous-version) ]; then
+    if [ -e /var/lib/update_engine/prefs/full-response ] && [ $(stat -L --printf='%Y' /var/lib/update_engine/prefs/full-response) -ge $(stat -L --printf='%Y' /var/lib/update_engine/prefs/previous-version) ]; then
         rm -f "/var/lib/update_engine/oem-${OEMID}.raw"
         sysext_download "oem-${OEMID}.gz" "/var/lib/update_engine/oem-${OEMID}.raw" /var/lib/update_engine/prefs/full-response
     fi
@@ -148,6 +148,7 @@ if [ "${OEMID}" != "" ] && { [ -e "${INSTALL_MNT}/share/flatcar/oems/${OEMID}" ]
           PAYLOADSERVER=bincache-server
           PAYLOADNAME="flatcar_test_update-oem-${OEMID}.gz"
         fi
+        echo "Falling back to ${PAYLOADSERVER} for extension 'oem-${OEMID}'" >&2
         sysext_download "${PAYLOADNAME}" "/var/lib/update_engine/oem-${OEMID}.raw" "${PAYLOADSERVER}"
     fi
     if [ "${SUCCESS}" = false ]; then
@@ -194,7 +195,7 @@ for NAME in $(grep -h -o '^[^#]*' /etc/flatcar/enabled-sysext.conf /usr/share/fl
     # which only works with a new update-engine client that creates "full-response",
     # and we also have to check that this file was created fresh for this update operation
     # (relies on the reset of /var/lib/update_engine/prefs/previous-version that old clients also do)
-    if [ -e /var/lib/update_engine/prefs/full-response ] && [ $(stat -L --printf='%Y' /var/lib/update_engine/prefs/full-response) -gt $(stat -L --printf='%Y' /var/lib/update_engine/prefs/previous-version) ]; then
+    if [ -e /var/lib/update_engine/prefs/full-response ] && [ $(stat -L --printf='%Y' /var/lib/update_engine/prefs/full-response) -ge $(stat -L --printf='%Y' /var/lib/update_engine/prefs/previous-version) ]; then
         rm -f "/var/lib/update_engine/flatcar-${NAME}.raw"
         sysext_download "flatcar-${NAME}.gz" "/var/lib/update_engine/flatcar-${NAME}.raw" /var/lib/update_engine/prefs/full-response
     fi
@@ -207,6 +208,7 @@ for NAME in $(grep -h -o '^[^#]*' /etc/flatcar/enabled-sysext.conf /usr/share/fl
           PAYLOADSERVER=bincache-server
           PAYLOADNAME="flatcar_test_update-flatcar-${NAME}.gz"
         fi
+        echo "Falling back to ${PAYLOADSERVER} for extension 'flatcar-${NAME}'" >&2
         sysext_download "${PAYLOADNAME}" "/var/lib/update_engine/flatcar-${NAME}.raw" "${PAYLOADSERVER}"
     fi
     if [ "${SUCCESS}" = false ]; then

--- a/src/update_engine/omaha_request_action.cc
+++ b/src/update_engine/omaha_request_action.cc
@@ -243,13 +243,15 @@ string XmlEncode(const string& input) {
 OmahaRequestAction::OmahaRequestAction(SystemState* system_state,
                                        OmahaEvent* event,
                                        HttpFetcher* http_fetcher,
-                                       bool ping_only)
+                                       bool ping_only,
+                                       bool store_response)
     : system_state_(system_state),
       event_(event),
       http_fetcher_(http_fetcher),
       ping_only_(ping_only),
       ping_active_days_(0),
-      ping_roll_call_days_(0) {
+      ping_roll_call_days_(0),
+      store_response_(store_response) {
   params_ = system_state->request_params();
 }
 
@@ -614,8 +616,10 @@ void OmahaRequestAction::TransferComplete(HttpFetcher *fetcher,
   string current_response(response_buffer_.begin(), response_buffer_.end());
   LOG(INFO) << "Omaha request response: " << current_response;
 
-  LOG_IF(WARNING, !system_state_->prefs()->SetString(kPrefsFullResponse, current_response))
-      << "Unable to write full response.";
+  if (store_response_) {
+    LOG_IF(WARNING, !system_state_->prefs()->SetString(kPrefsFullResponse, current_response))
+        << "Unable to write full response.";
+  }
 
   // Events are best effort transactions -- assume they always succeed.
   if (IsEvent()) {

--- a/src/update_engine/omaha_request_action.h
+++ b/src/update_engine/omaha_request_action.h
@@ -115,7 +115,8 @@ class OmahaRequestAction : public Action<OmahaRequestAction>,
   OmahaRequestAction(SystemState* system_state,
                      OmahaEvent* event,
                      HttpFetcher* http_fetcher,
-                     bool ping_only);
+                     bool ping_only,
+                     bool store_response);
   virtual ~OmahaRequestAction();
   typedef ActionTraits<OmahaRequestAction>::InputObjectType InputObjectType;
   typedef ActionTraits<OmahaRequestAction>::OutputObjectType OutputObjectType;
@@ -203,6 +204,9 @@ class OmahaRequestAction : public Action<OmahaRequestAction>,
   // are sent to Omaha.
   int ping_active_days_;
   int ping_roll_call_days_;
+
+  // If true, store full response to XML dump file for the postinst action.
+  bool store_response_;
 
   DISALLOW_COPY_AND_ASSIGN(OmahaRequestAction);
 };

--- a/src/update_engine/omaha_request_action_unittest.cc
+++ b/src/update_engine/omaha_request_action_unittest.cc
@@ -137,7 +137,8 @@ bool TestUpdateCheck(PrefsInterface* prefs,
   OmahaRequestAction action(&mock_system_state,
                             NULL,
                             fetcher,
-                            ping_only);
+                            ping_only,
+                            false);
   processor.EnqueueAction(&action);
 
   ObjectCollectorAction<OmahaResponse> collector_action;
@@ -169,7 +170,7 @@ void TestEvent(OmahaRequestParams params,
   ActionProcessor processor;
   ActionTestDelegate<OmahaRequestAction> delegate;
 
-  OmahaRequestAction action(&mock_system_state, event, fetcher, false);
+  OmahaRequestAction action(&mock_system_state, event, fetcher, false, false);
   processor.EnqueueAction(&action);
 
   delegate.RunProcessorInMainLoop(&processor);
@@ -230,6 +231,7 @@ TEST(OmahaRequestActionTest, NoOutputPipeTest) {
   OmahaRequestAction action(&mock_system_state, NULL,
                             new MockHttpFetcher(http_response.data(),
                                                 http_response.size()),
+                            false,
                             false);
   processor.EnqueueAction(&action);
 
@@ -412,6 +414,7 @@ TEST(OmahaRequestActionTest, TerminateTransferTest) {
   OmahaRequestAction action(&mock_system_state, NULL,
                             new MockHttpFetcher(http_response.data(),
                                                 http_response.size()),
+                            false,
                             false);
   TerminateEarlyTestProcessorDelegate delegate;
   delegate.loop_ = loop;
@@ -517,7 +520,7 @@ TEST(OmahaRequestActionTest, FormatUpdateCheckOutputTest) {
   NiceMock<PrefsMock> prefs;
   EXPECT_CALL(prefs, GetString(kPrefsPreviousVersion, _))
       .WillOnce(DoAll(SetArgumentPointee<1>(string("")), Return(true)));
-  EXPECT_CALL(prefs, SetString(kPrefsFullResponse, _)).Times(1);
+  EXPECT_CALL(prefs, SetString(kPrefsFullResponse, _)).Times(0);
   EXPECT_CALL(prefs, SetString(kPrefsPreviousVersion, _)).Times(1);
   ASSERT_FALSE(TestUpdateCheck(&prefs,
                                GetDefaultTestParams(),
@@ -586,6 +589,7 @@ TEST(OmahaRequestActionTest, IsEventTest) {
       NULL,
       new MockHttpFetcher(http_response.data(),
                           http_response.size()),
+      false,
       false);
   EXPECT_FALSE(update_check_action.IsEvent());
 
@@ -596,6 +600,7 @@ TEST(OmahaRequestActionTest, IsEventTest) {
       new OmahaEvent(OmahaEvent::kTypeUpdateComplete),
       new MockHttpFetcher(http_response.data(),
                           http_response.size()),
+      false,
       false);
   EXPECT_TRUE(event_action.IsEvent());
 }

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -188,7 +188,8 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
       new OmahaRequestAction(system_state_,
                              NULL,
                              update_check_fetcher,  // passes ownership
-                             false));
+                             false,
+                             true)); // Store full response for the update check
   shared_ptr<OmahaResponseHandlerAction> response_handler_action(
       new OmahaResponseHandlerAction(system_state_));
   shared_ptr<FilesystemCopierAction> filesystem_copier_action(
@@ -199,6 +200,7 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
                              new OmahaEvent(
                                  OmahaEvent::kTypeUpdateDownloadStarted),
                              new LibcurlHttpFetcher(),
+                             false,
                              false));
   LibcurlHttpFetcher* download_fetcher = new LibcurlHttpFetcher();
   download_fetcher->set_check_certificate(CertificateChecker::kDownload);
@@ -214,6 +216,7 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
                              new OmahaEvent(
                                  OmahaEvent::kTypeUpdateDownloadFinished),
                              new LibcurlHttpFetcher(),
+                             false,
                              false));
   shared_ptr<FilesystemCopierAction> filesystem_verifier_action(
       new FilesystemCopierAction(true));
@@ -227,6 +230,7 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
       new OmahaRequestAction(system_state_,
                              new OmahaEvent(OmahaEvent::kTypeUpdateComplete),
                              new LibcurlHttpFetcher(),
+                             false,
                              false));
 
   download_action->set_delegate(this);
@@ -620,6 +624,7 @@ bool UpdateAttempter::ScheduleErrorEventAction() {
       new OmahaRequestAction(system_state_,
                              error_event_.release(),  // Pass ownership.
                              new LibcurlHttpFetcher(),
+                             false,
                              false));
   actions_.push_back(shared_ptr<AbstractAction>(error_event_action));
   processor_->EnqueueAction(error_event_action.get());
@@ -690,7 +695,8 @@ void UpdateAttempter::PingOmaha() {
         new OmahaRequestAction(system_state_,
                                NULL,
                                new LibcurlHttpFetcher(),
-                               true));
+                               true,
+                               false));
     actions_.push_back(shared_ptr<OmahaRequestAction>(ping_action));
     processor_->set_delegate(NULL);
     processor_->EnqueueAction(ping_action.get());

--- a/src/update_engine/update_attempter_unittest.cc
+++ b/src/update_engine/update_attempter_unittest.cc
@@ -122,7 +122,7 @@ TEST_F(UpdateAttempterTest, ActionCompletedOmahaRequestTest) {
   std::unique_ptr<MockHttpFetcher> fetcher(new MockHttpFetcher("", 0));
   fetcher->FailTransfer(500);  // Sets the HTTP response code.
   OmahaRequestAction action(&mock_system_state_, NULL,
-                            fetcher.release(), false);
+                            fetcher.release(), false, false);
   ObjectCollectorAction<OmahaResponse> collector_action;
   BondActions(&action, &collector_action);
   OmahaResponse response;
@@ -168,7 +168,7 @@ TEST_F(UpdateAttempterTest, GetErrorCodeForActionTest) {
 
   MockSystemState mock_system_state;
   OmahaRequestAction omaha_request_action(&mock_system_state, NULL,
-                                          NULL, false);
+                                          NULL, false, false);
   EXPECT_EQ(kActionCodeOmahaRequestError,
             GetErrorCodeForAction(&omaha_request_action, kActionCodeError));
   OmahaResponseHandlerAction omaha_response_handler_action(&mock_system_state_);


### PR DESCRIPTION
The full Omaha XML response is stored to a file for the postinst action, but we only want the response for the initial update check passed this way and not overwrite the file with responses for state reports. Only store the Omaha XML response for the update check and not all of the interaction with the Omaha server.

Fixes https://github.com/flatcar/Flatcar/issues/1281

## How to use

Backport to Beta

Fixes https://github.com/flatcar/Flatcar/issues/1281

## Testing done

From the new image to the new image works with
```
flatcar-update -V 1.2.3 -E flatcar_test_update-oem-qemu.gz -P flatcar_test_update.gz
```
and does not use the fallback path.

The previous-version file is modified earlier than the full-response file until the update is complete when it gets modified again:
```
localhost /var/lib/update_engine/prefs # stat -L --printf '%y %n\n' * | sort
2023-12-11 20:00:11.699914565 +0000 aleph-version
2023-12-11 20:00:46.365035407 +0000 delta-update-failures
2023-12-11 20:05:54.082000000 +0000 current-response-signature
2023-12-11 20:05:54.083000000 +0000 current-url-failure-count
2023-12-11 20:05:54.083000000 +0000 current-url-index
2023-12-11 20:10:35.279020204 +0000 previous-version
2023-12-11 20:10:35.283020273 +0000 full-response
2023-12-11 20:10:35.284020290 +0000 resumed-update-failures
2023-12-11 20:10:35.284020290 +0000 update-check-response-hash
2023-12-11 20:10:44.267168119 +0000 manifest-metadata-size
2023-12-11 20:11:05.859465962 +0000 update-state-next-data-offset
2023-12-11 20:11:05.859465962 +0000 update-state-next-operation
2023-12-11 20:11:05.859465962 +0000 update-state-sha-256-context
2023-12-11 20:11:05.859465962 +0000 update-state-signature-blob
2023-12-11 20:11:05.859465962 +0000 update-state-signed-sha-256-context
2023-12-11 20:11:05.955467137 +0000 backoff-expiry-time
2023-12-11 20:11:05.955467137 +0000 payload-attempt-number
                                                                               
Broadcast message from locksmithd at 2023-12-11 20:11:10.88278973 +0000 UTC m=+
System reboot in 5 minutes!                                                    
                                                                               
localhost /var/lib/update_engine/prefs # stat -L --printf '%y %n\n' * | sort
2023-12-11 20:00:11.699914565 +0000 aleph-version
2023-12-11 20:05:54.082000000 +0000 current-response-signature
2023-12-11 20:05:54.083000000 +0000 current-url-failure-count
2023-12-11 20:05:54.083000000 +0000 current-url-index
2023-12-11 20:10:35.283020273 +0000 full-response
2023-12-11 20:11:05.955467137 +0000 backoff-expiry-time
2023-12-11 20:11:05.955467137 +0000 payload-attempt-number
2023-12-11 20:11:10.872525484 +0000 delta-update-failures
2023-12-11 20:11:10.872525484 +0000 manifest-metadata-size
2023-12-11 20:11:10.872525484 +0000 previous-version
2023-12-11 20:11:10.872525484 +0000 resumed-update-failures
2023-12-11 20:11:10.872525484 +0000 update-check-response-hash
2023-12-11 20:11:10.872525484 +0000 update-state-next-data-offset
2023-12-11 20:11:10.872525484 +0000 update-state-next-operation
2023-12-11 20:11:10.872525484 +0000 update-state-sha-256-context
2023-12-11 20:11:10.872525484 +0000 update-state-signature-blob
2023-12-11 20:11:10.872525484 +0000 update-state-signed-sha-256-context

```

I've also tested it with Nebraska to ensure that only the first response is stored (in Nebraska it varies). This is the case and the update went well without triggering the fallback path (which would not work).

Upload of the payloads was done with `GITHUB_TOKEN=x NOUPLOAD=1 ./upload_package /var/tmp/test/ http://localhost:8000 notused 9999.9.9`  and then changing the package URL to a local http server reachable by the VM.

Here again we see that the modification time behaves as above:
```
localhost /var/lib/update_engine/prefs # stat -L --printf '%y %n\n' * | sort
2023-12-11 20:00:11.699914565 +0000 aleph-version
2023-12-11 20:11:10.872525484 +0000 delta-update-failures
2023-12-12 10:44:59.771555986 +0000 update-server-cert-0-0
2023-12-12 10:44:59.771555986 +0000 update-server-cert-0-1
2023-12-12 10:44:59.771555986 +0000 update-server-cert-0-2
2023-12-12 12:29:08.607727589 +0000 previous-version
2023-12-12 12:29:08.630727557 +0000 backoff-expiry-time
2023-12-12 12:29:08.630727557 +0000 current-response-signature
2023-12-12 12:29:08.630727557 +0000 current-url-failure-count
2023-12-12 12:29:08.630727557 +0000 current-url-index
2023-12-12 12:29:08.630727557 +0000 full-response
2023-12-12 12:29:08.630727557 +0000 payload-attempt-number
2023-12-12 12:29:08.641727542 +0000 resumed-update-failures
2023-12-12 12:29:08.641727542 +0000 update-check-response-hash
2023-12-12 12:29:08.641727542 +0000 update-state-signature-blob
2023-12-12 12:29:08.641727542 +0000 update-state-signed-sha-256-context
2023-12-12 12:29:14.693718961 +0000 manifest-metadata-size
2023-12-12 12:29:35.307686556 +0000 update-state-sha-256-context
2023-12-12 12:29:35.308686554 +0000 update-state-next-data-offset
2023-12-12 12:29:35.308686554 +0000 update-state-next-operation
                                                                               
Broadcast message from locksmithd at 2023-12-12 12:29:43.93300407 +0000 UTC m=+
System reboot in 5 minutes!                                                    
                                                                               

localhost /var/lib/update_engine/prefs # stat -L --printf '%y %n\n' * | sort
2023-12-11 20:00:11.699914565 +0000 aleph-version
2023-12-12 10:44:59.771555986 +0000 update-server-cert-0-0
2023-12-12 10:44:59.771555986 +0000 update-server-cert-0-1
2023-12-12 10:44:59.771555986 +0000 update-server-cert-0-2
2023-12-12 12:29:08.630727557 +0000 current-response-signature
2023-12-12 12:29:08.630727557 +0000 current-url-failure-count
2023-12-12 12:29:08.630727557 +0000 current-url-index
2023-12-12 12:29:08.630727557 +0000 full-response
2023-12-12 12:29:39.126680025 +0000 backoff-expiry-time
2023-12-12 12:29:39.126680025 +0000 payload-attempt-number
2023-12-12 12:29:43.924671590 +0000 delta-update-failures
2023-12-12 12:29:43.924671590 +0000 manifest-metadata-size
2023-12-12 12:29:43.924671590 +0000 previous-version
2023-12-12 12:29:43.924671590 +0000 resumed-update-failures
2023-12-12 12:29:43.924671590 +0000 update-check-response-hash
2023-12-12 12:29:43.924671590 +0000 update-state-next-data-offset
2023-12-12 12:29:43.924671590 +0000 update-state-next-operation
2023-12-12 12:29:43.924671590 +0000 update-state-sha-256-context
2023-12-12 12:29:43.924671590 +0000 update-state-signature-blob
2023-12-12 12:29:43.924671590 +0000 update-state-signed-sha-256-context
```