### PR TITLE
subprocess: Forward proxy env for postinstall script

### DIFF
--- a/src/update_engine/subprocess.cc
+++ b/src/update_engine/subprocess.cc
@@ -88,7 +88,7 @@ void FreeArgvInError(char** argv) {
 // Note: Caller responsible for free()ing the returned value!
 // Will return NULL on failure and free any allocated memory.
 char** ArgPointer() {
-  const char* keys[] = {"LD_LIBRARY_PATH", "PATH"};
+  const char* keys[] = {"LD_LIBRARY_PATH", "PATH", "ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY"};
   char** ret = new char*[arraysize(keys) + 1];
   int pointer = 0;
   for (size_t i = 0; i < arraysize(keys); i++) {


### PR DESCRIPTION
The proxy env vars for curl can be set up for the update-engine service but so far weren't forwarded to the postinstall script. Now that we download from it, we need to forward them.
Forward the env vars for curl and ue-rs download_sysext (Flatcar Stable currently uses curl, Alpha uses ue-rs).

## How to use

Backport to Stable and LTS.

## Testing done

Checked that these env vars pop up when set up. First I tested
```
# /etc/systemd/system/update-engine.service.d/override.conf
[Service]
Environment="LD_LIBRARY_PATH=/usr/lib64"
```
with `sudo flatcar-update …` and it made one more env var entry (`2 vars`). The same should happen for the proxy vars.
```
sudo strace -f -e trace=execve -p $(pgrep update_engine) 2>&1 | grep postinst
[pid 163396] execve("/tmp/au_postint_mount.DzIv8e/postinst", ["/tmp/au_postint_mount.DzIv8e/pos"..., "/dev/vda4", "KERNEL=/boot/flatcar/vmlinuz-b"], 0x5601b610aaf0 /* 2 vars */) = 0
```

With setting `Environment=HTTPS_PROXY=http://a.b` on a patched system and running `sudo ./flatcar-update -V 3850.0.0 -F` with this patch to have it download the payload as fallback:
```
$ diff -u /usr/bin/flatcar-update flatcar-update 
--- /usr/bin/flatcar-update	2024-01-24 11:38:22.000000000 +0000
+++ flatcar-update	2024-01-24 13:40:51.383160024 +0000
@@ -113,7 +113,7 @@
 fi
 
 # Use the old mount point for compatibility with old instances, where the script gets copied to
-OEMID=$({ grep -m 1 -o "^ID=.*" /usr/share/oem/oem-release 2> /dev/null || true ; } | cut -d = -f 2)
+OEMID= # $({ grep -m 1 -o "^ID=.*" /usr/share/oem/oem-release 2> /dev/null || true ; } | cut -d = -f 2)
 
 # Determine what to download from release server if no local payload is given.
 # Using /usr/share/flatcar/oems/ from the currently running version means the download is only best-effort
 ```
we see the `2 vars` strace log as well, indicating that the env var is forwarded, and we get a failed update because the fallback download can't reach https with a non-existing proxy:
```
Jan 24 13:42:57 localhost update_engine[2565]: I0124 13:42:57.641688  2565 subprocess.cc:43] Subprocess status: 1
Jan 24 13:42:57 localhost update_engine[2565]: I0124 13:42:57.641752  2565 subprocess.cc:46] Subprocess output:
Jan 24 13:42:57 localhost update_engine[2565]: Args { output_dir: "/var/lib/update_engine/ue-rs/", input_xml: Some("/var/lib/update_engine/prefs/full-response"), payload_url: None, pubkey_file: "/usr/share/update_engine/update-payload-key.pub.pem", image_match: ["oem-qemu.gz"], print_progress: false }
Jan 24 13:42:57 localhost update_engine[2565]: mv: cannot stat '/var/lib/update_engine/ue-rs//oem-qemu.raw': No such file or directory
Jan 24 13:42:57 localhost update_engine[2565]: Falling back to release-server for extension 'oem-qemu'
Jan 24 13:42:57 localhost update_engine[2565]: Args { output_dir: "/var/lib/update_engine/ue-rs/", input_xml: None, payload_url: Some("https://update.release.flatcar-linux.net/amd64-usr/3850.0.0/oem-qemu.gz"), pubkey_file: "/usr/share/update_engine/update-payload-key.pub.pem", image_match: [], print_progress: false }
Jan 24 13:42:57 localhost update_engine[2565]: Error: unable to download data(url Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("update.release.flatcar-linux.net")), port: None, path: "/amd64-usr/3850.0.0/oem-qemu.gz", query: None, fragment: None })
Jan 24 13:42:57 localhost update_engine[2565]: Caused by:
Jan 24 13:42:57 localhost update_engine[2565]:     0: client get & send"https://update.release.flatcar-linux.net/amd64-usr/3850.0.0/oem-qemu.gz" failed
Jan 24 13:42:57 localhost update_engine[2565]:     1: error sending request for url (https://update.release.flatcar-linux.net/amd64-usr/3850.0.0/oem-qemu.gz): error trying to connect: dns error: failed to lookup address information: Name or service not known
Jan 24 13:42:57 localhost update_engine[2565]:     2: error trying to connect: dns error: failed to lookup address information: Name or service not known
Jan 24 13:42:57 localhost update_engine[2565]:     3: dns error: failed to lookup address information: Name or service not known
Jan 24 13:42:57 localhost update_engine[2565]:     4: failed to lookup address information: Name or service not known
Jan 24 13:42:57 localhost update_engine[2565]: Failed to download required OEM update payload
```
The same happens with `sudo ./flatcar-update -V 3760.2.0 -F` which uses curl instead of ue-rs (the error message is `curl: (5) Could not resolve proxy: a.b`).