### PR TITLE
flatcar-postinst: Handle airgapped self-hosted nebraska instances

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -96,8 +96,9 @@ sysext_download() {
       url="https://bincache.flatcar-linux.net/images/${FLATCAR_BOARD/-usr}/${NEXT_VERSION}/${name}"
     else
       base=$(grep -m 1 -o 'codebase="[^"]*"' "${from}" | cut -d '"' -f 2)
-      entries=$(grep -m 1 -o "<package name=\"${name}\"[^>]*" "${from}")
-      url="${base}/${name}"
+      entries=$(grep -m 1 -o "<package name=\"[^\"]*${name}\"[^>]*" "${from}")
+      name=$(echo "${entries}" | { grep -o 'name="[^"]*' || true; } | cut -d '"' -f 2)
+      url="${base%/}/${name}"
       size=$(echo "${entries}" | grep -o 'size="[0-9]*' | cut -d '"' -f 2)
       hash=$(echo "${entries}" | { grep -o -P 'hash="[^"]*' || true ; } | cut -d '"' -f 2) # openssl dgst -binary -sha1 < "$PAYLOAD" | base64
       hash_sha256=$(echo "${entries}" | { grep -o -P 'hash_sha256="[^"]*' || true ; } | cut -d '"' -f 2) # sha256sum -b "$PAYLOAD" | cut -d " " -f 1


### PR DESCRIPTION
This is a backport of the equivalent of https://github.com/flatcar/scripts/pull/1580 to 3815, without switching to ue-rs.

Tested on the full-response from the airgapped environment (in commit message):

```bash
$ cat flatcar-postinst
set -euo pipefail
set -x
umask 0022
OEMID=vmware
sysext_download() {
    ....
}
sysext_download "oem-${OEMID}.gz" "./var/lib/update_engine/oem-${OEMID}.raw" test.xml
```
Output:
```bash
$ bash -x flatcar-postinst
+ set -euo pipefail
+ set -x
+ umask 0022
+ OEMID=vmware
+ sysext_download oem-vmware.gz ./var/lib/update_engine/oem-vmware.raw test2.xml
+ local name=oem-vmware.gz
+ local target=./var/lib/update_engine/oem-vmware.raw
+ local from=test2.xml
+ local base=
+ local entries=
+ local hash=
+ local size=
+ local url=
+ local ret
+ SUCCESS=false
+ set +e
+ set -e
+ '[' test2.xml = release-server ']'
+ '[' test2.xml = bincache-server ']'
++ grep -m 1 -o 'codebase="[^"]*"' test2.xml
++ cut -d '"' -f 2
+ base=https://nebraska-example.org/flatcar/
++ grep -m 1 -o '<package name="[^"]*oem-vmware.gz"[^>]*' test2.xml
+ entries='<package name="extrafile-amd64-3815.2.0-oem-vmware.gz" hash="llmt48kEE1pZxHbhE86zTczZMmY=" hash_sha256="7c4095f16579402d73ea42a63be63b2c92d98457303a080399d2a5bb33f46f88" size="1536465" required="false"/'
++ echo '<package name="extrafile-amd64-3815.2.0-oem-vmware.gz" hash="llmt48kEE1pZxHbhE86zTczZMmY=" hash_sha256="7c4095f16579402d73ea42a63be63b2c92d98457303a080399d2a5bb33f46f88" size="1536465" required="false"/'
++ grep -o 'name="[^"]*'
++ cut -d '"' -f 2
+ name=extrafile-amd64-3815.2.0-oem-vmware.gz
+ url=https://nebraska-example.org/flatcar/extrafile-amd64-3815.2.0-oem-vmware.gz
++ echo '<package name="extrafile-amd64-3815.2.0-oem-vmware.gz" hash="llmt48kEE1pZxHbhE86zTczZMmY=" hash_sha256="7c4095f16579402d73ea42a63be63b2c92d98457303a080399d2a5bb33f46f88" size="1536465" required="false"/'
++ grep -o 'size="[0-9]*'
++ cut -d '"' -f 2
+ size=1536465
++ echo '<package name="extrafile-amd64-3815.2.0-oem-vmware.gz" hash="llmt48kEE1pZxHbhE86zTczZMmY=" hash_sha256="7c4095f16579402d73ea42a63be63b2c92d98457303a080399d2a5bb33f46f88" size="1536465" required="false"/'
++ grep -o -P 'hash="[^"]*'
++ cut -d '"' -f 2
+ hash=llmt48kEE1pZxHbhE86zTczZMmY=
++ echo '<package name="extrafile-amd64-3815.2.0-oem-vmware.gz" hash="llmt48kEE1pZxHbhE86zTczZMmY=" hash_sha256="7c4095f16579402d73ea42a63be63b2c92d98457303a080399d2a5bb33f46f88" size="1536465" required="false"/'
++ grep -o -P 'hash_sha256="[^"]*'
++ cut -d '"' -f 2
+ hash_sha256=7c4095f16579402d73ea42a63be63b2c92d98457303a080399d2a5bb33f46f88
+ rm -f ./var/lib/update_engine/oem-vmware.raw.tmp
+ curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 -o ./var/lib/update_engine/oem-vmware.raw.tmp https://nebraska-example.org/flatcar/extrafile-amd64-3815.2.0-oem-vmware.gz
curl: (6) Could not resolve host: nebraska-example.org
curl: (6) Could not resolve host: nebraska-example.org
....
```