### PR TITLE
Mount btrfs fs with rescue= option

### DIFF
--- a/src/update_engine/postinstall_runner_action.cc
+++ b/src/update_engine/postinstall_runner_action.cc
@@ -50,7 +50,7 @@ void PostinstallRunnerAction::PerformAction() {
                temp_rootfs_dir_.c_str(),
                "btrfs",
                mountflags,
-               "norecovery");
+               "rescue=nologreplay");
     if (errno == EEXIST) {
       /* When trying to mount an identical btrfs image twice because the old
        * and new partition are identical, the kernel refuses because same UUIDs


### PR DESCRIPTION
It looks like 'norecovery' is deprecated and has been removed in the v6.8-rc1 kernel. Replace it with 'rescue=nologreplay', which is a replacement implemented since v5.9. The standalone 'nologreplay' option is also deprecated.

See: https://lore.kernel.org/linux-btrfs/91c34f25266be07585b75fde0b580b9118f8786e.1700673401.git.josef@toxicpanda.com/
