### PR TITLE
.github: rename default branch from flatcar-master to main

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,9 +2,9 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ flatcar-master ]
+    branches: [ main ]
   pull_request:
-    branches: [ flatcar-master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Rename the default branch from `flatcar-master` to `main`, following the general Flatcar repo settings guideline.

Note: we should not touch download URLs of seismograph yet, which should be updated afterwards.
