### PR TITLE
Potential fix for code scanning alert no. 3: Unsigned difference expression compared to zero

### DIFF
--- a/src/update_engine/extent_writer.cc
+++ b/src/update_engine/extent_writer.cc
@@ -18,7 +18,7 @@ bool DirectExtentWriter::Write(const void* bytes, size_t count) {
     return true;
   const char* c_bytes = reinterpret_cast<const char*>(bytes);
   size_t bytes_written = 0;
-  while (count - bytes_written > 0) {
+  while (bytes_written < count) {
     TEST_AND_RETURN_FALSE(next_extent_index_ < extents_.size());
     uint64_t bytes_remaining_next_extent =
         extents_[next_extent_index_].num_blocks() * block_size_ -


### PR DESCRIPTION
Potential fix for [https://github.com/flatcar/update_engine/security/code-scanning/3](https://github.com/flatcar/update_engine/security/code-scanning/3)

To fix the issue, we need to avoid unsigned subtraction in the loop condition. Instead of `count - bytes_written > 0`, we can directly compare `bytes_written` with `count` using `bytes_written < count`. This approach avoids the risk of underflow and achieves the same logical result.

The fix involves replacing the condition on line 21 with `bytes_written < count`. This change ensures that the loop behaves correctly regardless of the values of `count` and `bytes_written`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
