### PR TITLE
Potential fix for code scanning alert no. 2: Use of string after lifetime ends

### DIFF
--- a/src/update_engine/test_http_server.cc
+++ b/src/update_engine/test_http_server.cc
@@ -466,7 +466,8 @@ class UrlTerms {
     return terms[index];
   }
   inline const char *GetCStr(const off_t index) const {
-    return Get(index).c_str();
+    const string& term = Get(index);
+    return term.c_str();
   }
   inline int GetInt(const off_t index) const {
     return atoi(GetCStr(index));

--- a/src/update_engine/test_http_server.cc
+++ b/src/update_engine/test_http_server.cc
@@ -466,8 +466,7 @@ class UrlTerms {
     return terms[index];
   }
   inline const char *GetCStr(const off_t index) const {
-    const string& term = Get(index);
-    return term.c_str();
+    return terms[index].c_str();
   }
   inline int GetInt(const off_t index) const {
     return atoi(GetCStr(index));


### PR DESCRIPTION
Potential fix for [https://github.com/flatcar/update_engine/security/code-scanning/2](https://github.com/flatcar/update_engine/security/code-scanning/2)

To fix the issue, we need to ensure that the lifetime of the `std::string` object returned by `Get(index)` is extended so that the pointer returned by `c_str()` remains valid. The best way to achieve this is to store the `std::string` object in a local variable within the `GetCStr` method and return the pointer to its character array. This ensures that the `std::string` object outlives the call to `c_str()`.

Changes will be made to the `GetCStr` method in the `UrlTerms` class. Specifically:
1. Store the result of `Get(index)` in a local variable.
2. Call `c_str()` on the local variable and return the pointer.

No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
