### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,5 +1,8 @@
 name: C/C++ CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/flatcar/update_engine/security/code-scanning/1](https://github.com/flatcar/update_engine/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only needs to read the repository contents to perform the build and tests, we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has the least privilege required for the workflow to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
