### PR TITLE
postinst: Make sure Flatcar extension folder exists

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -229,6 +229,7 @@ for NAME in $(grep -h -o '^[^#]*' /etc/flatcar/enabled-sysext.conf /usr/share/fl
         echo "Failed to download required OEM update payload" >&2
         exit 1
     fi
+    mkdir -p /etc/flatcar/sysext
     mv  "/var/lib/update_engine/flatcar-${NAME}.raw" "/etc/flatcar/sysext/flatcar-${NAME}-${NEXT_VERSION}.raw"
 done
 


### PR DESCRIPTION
When a Flatcar extension file is created on an old node that doesn't yet support them but the update will, and already downloads it, then we also need to create the folder because it's not existing yet.

Fixes https://github.com/flatcar/Flatcar/issues/1788


## How to use

## Testing done

Tested with `./flatcar-update -V 9999.9.9 -P flatcar_test_update.gz -E flatcar_test_update-flatcar-python.gz -D -A` when updating from LTS 3033.3.18 with `/etc/flatcar/enabled-sysext.conf` containing `python`

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
