### PR TITLE
postinst: fix the removal of all extensions

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -191,16 +191,22 @@ fi
 # and when the name is prefixed with a "-" it means that the extension should be disabled if enabled by default in the file from /usr.
 # It may contain comments starting with "#" at the beginning of a line or after a name.
 # The file is also used in bootengine to know which extensions to enable.
-# Note that we don't need "{ grep || true ; }" to suppress the match return code because in for _ in $(grep...) return codes are ignored
-for NAME in $(grep -h -o '^[^#]*' /etc/flatcar/enabled-sysext.conf /usr/share/flatcar/enabled-sysext.conf | grep -v -x -f <(grep '^-' /etc/flatcar/enabled-sysext.conf | cut -d - -f 2-) | grep -v -P '^(-).*'); do
-    KEEP="/etc/flatcar/sysext/flatcar-${NAME}-${VERSION}.raw"
-    shopt -s nullglob
-    # Delete sysext images that belonged to the now overwritten /usr partition but keep the sysext image for the current version
-    for OLD_IMAGE in /etc/flatcar/sysext/flatcar*raw; do
-      if [ "${OLD_IMAGE}" != "${KEEP}" ] && [ -f "${OLD_IMAGE}" ]; then
-        rm -f "${OLD_IMAGE}"
-      fi
+ENABLED_EXTENSIONS=$(grep -h -o '^[^#]*' /etc/flatcar/enabled-sysext.conf /usr/share/flatcar/enabled-sysext.conf | grep -v -x -f <(grep '^-' /etc/flatcar/enabled-sysext.conf | cut -d - -f 2-) | grep -v -P '^(-).*' || true)
+shopt -s nullglob
+# Delete sysext images that belonged to the now overwritten /usr partition but keep the sysext image for the current version
+for OLD_IMAGE in /etc/flatcar/sysext/flatcar*raw; do
+    SHOULD_KEEP=false
+    for NAME in ${ENABLED_EXTENSIONS}; do
+        if [ "${OLD_IMAGE}" == "/etc/flatcar/sysext/flatcar-${NAME}-${VERSION}.raw" ]; then
+            SHOULD_KEEP=true
+            break
+        fi
     done
+    if [ "${SHOULD_KEEP}" == false ] && [ -f "${OLD_IMAGE}" ]; then
+        rm -f "${OLD_IMAGE}"
+    fi
+done
+for NAME in ${ENABLED_EXTENSIONS}; do
     # Note that in the case of VERSION=NEXT_VERSION we will replace the running sysext and maybe it's better
     # to do so than not because it allows to recover from a corrupted file (where the corruption happened on disk)
     SUCCESS=false


### PR DESCRIPTION
When upgrading to a new version, if there are two or more extensions enabled, all extensions are deleted due to incorrect verification logic. Only the last downloaded extension remains. This makes it impossible to boot the system after a reboot in closed environments due to lack of access to https://update.release.flatcar-linux.net

## How to use

## Testing done
An image was created in the flatcar-4426 branch, which was added with extensions to the local nginx file server. The package was created on the local nebraska server. 
With extensions enabled:
```
# butane.yaml:
variant: flatcar
version: 1.0.0
storage:
  files:
    - path: /etc/flatcar/enabled-sysext.conf
      mode: 0644
      contents:
        inline: |
          python
          zfs
    - path: /etc/flatcar/update.conf
      overwrite: true
      mode: 0644
      contents:
        inline: |
          MACHINE_ALIAS="test-vm"
          GROUP=beta
          SERVER=http://172.18.0.5/v1/update/

# boot from https://bincache.flatcar-linux.net/images/amd64/4230.2.3+nightly-20251008-2100/flatcar_production_qemu_image.img 
with internet enabled


localhost ~ # ls -lah /etc/flatcar/sysext/
total 25M
drwxr-xr-x. 2 root root 4.0K Oct  9 18:17 .
drwxr-xr-x. 1 root root 4.0K Oct  9 18:17 ..
-rw-r--r--. 1 root root  20M Oct  9 18:17 flatcar-python-4230.2.3+nightly-20251008-2100.raw
-rw-r--r--. 1 root root 4.1M Oct  9 18:17 flatcar-zfs-4230.2.3+nightly-20251008-2100.raw

# Update
sudo update_engine_client -update

localhost ~ # ls -lah /etc/flatcar/sysext/
total 49M
drwxr-xr-x. 2 root root 4.0K Oct  9 18:24 .
drwxr-xr-x. 1 root root 4.0K Oct  9 18:24 ..
-rw-r--r--. 1 root root  20M Oct  9 18:17 flatcar-python-4230.2.3+nightly-20251008-2100.raw
-rw-r--r--. 1 root root  21M Oct  9 18:24 flatcar-python-4426.1.0+nightly-20251007-2100.raw
-rw-r--r--. 1 root root 4.1M Oct  9 18:17 flatcar-zfs-4230.2.3+nightly-20251008-2100.raw
-rw-r--r--. 1 root root 4.0M Oct  9 18:24 flatcar-zfs-4426.1.0+nightly-20251007-2100.raw
```


Without extensions enabled:
```
# butane.yaml:
variant: flatcar
version: 1.0.0
storage:
  files:
    - path: /etc/flatcar/update.conf
      overwrite: true
      mode: 0644
      contents:
        inline: |
          MACHINE_ALIAS="test-vm"
          GROUP=beta
          SERVER=http://172.18.0.5/v1/update/

# boot from https://bincache.flatcar-linux.net/images/amd64/4230.2.3+nightly-20251008-2100/flatcar_production_qemu_image.img

Flatcar Container Linux by Kinvolk beta 4230.2.3+nightly-20251008-2100 for QEMU
core@localhost ~ $ ls -lah /usr/share/flatcar/enabled-sysext.conf
ls: cannot access '/usr/share/flatcar/enabled-sysext.conf': No such file or directory
core@localhost ~ $ ls -lah /etc/flatcar/enabled-sysext.conf
ls: cannot access '/etc/flatcar/enabled-sysext.conf': No such file or directory

core@localhost ~ $ sudo update_engine_client -update
System reboot in 5 minutes!                                                    
  
LAST_CHECKED_TIME=1760035063
PROGRESS=0.000000
CURRENT_OP=UPDATE_STATUS_UPDATED_NEED_REBOOT
NEW_VERSION=4426.1.0+nightly-20251007-2100
NEW_SIZE=467964215
I20251009 18:38:09.153322  1718 update_engine_client.cc:198] Update succeeded -- reboot needed.

core@localhost ~ $ sudo reboot

core@localhost ~ $ cat /etc/os-release 
NAME="Flatcar Container Linux by Kinvolk"
ID=flatcar
ID_LIKE=coreos
VERSION=4426.1.0+nightly-20251007-2100
VERSION_ID=4426.1.0
BUILD_ID=nightly-20251007-2100
SYSEXT_LEVEL=1.0
PRETTY_NAME="Flatcar Container Linux by Kinvolk 4426.1.0+nightly-20251007-2100 (Oklo)"
ANSI_COLOR="38;5;75"
HOME_URL="https://flatcar.org/"
BUG_REPORT_URL="https://issues.flatcar.org"
FLATCAR_BOARD="amd64-usr"
CPE_NAME="cpe:2.3:o:flatcar-linux:flatcar_linux:4426.1.0+nightly-20251007-2100:*:*:*:*:*:*:*"
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
