### PR TITLE
flatcar-postinst: Use lazy unmount for /etc in temporary namespace

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -248,7 +248,7 @@ done
 # To fix this, remove any opaque markers for this directory. Other common folders which
 # we introduce later in the lowerdir could also be handled that way, e.g., /etc/cni/.
 if mountpoint -q /etc; then
-  unshare -m sh -c "umount /etc && mkdir -p /etc/extensions && attr -R -r overlay.opaque /etc/extensions || true"
+  unshare -m sh -c "umount -l /etc && mkdir -p /etc/extensions && attr -R -r overlay.opaque /etc/extensions || true"
 fi
 
 # Systemd version >= 256 does not boot anymore if cgroupv1 is enabled or SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 is set


### PR DESCRIPTION
There is a post-install action to prevent opaque directories (meaning any existing underlay directory is ignored) for those directories under /etc that the user might have created but we ship them later also in our /etc underlay. This action was not working when files were kept open under /etc because the unmount in the temporary namespace was not lazy. Use the lazy unmount option to address this.

## How to use

That's something I would like to backport.

## Testing done

Works, it runs again: `Could not remove "overlay.opaque" for /etc/extensions` is printed

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
