### PR TITLE
docs: add standardized CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+Welcome! We're so glad you're here and interested in contributing to Flatcar! 💖
+
+Whether you're fixing a bug, adding a feature, or improving docs — we appreciate you!
+
+For more detailed guidelines (finding issues, community meetings, PR lifecycle, commit message format, and more), check out the [main Flatcar CONTRIBUTING guide](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md).
+
+---
+
+## Repository Specific Guidelines
+
+Any guidelines specific to this repository that are not covered in the main contribution guide will be listed here.
+
+<!-- Add repo-specific guidelines below this line -->


### PR DESCRIPTION
## Summary

This PR adds a standardized `CONTRIBUTING.md` file that:

- Welcomes new contributors
- Links to the [main Flatcar CONTRIBUTING guide](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md)
- Provides a section for repo-specific guidelines

This change is part of a batch update across all Flatcar repositories to ensure consistent contribution documentation.

Ref: https://github.com/flatcar/Flatcar/issues/1865
