### PR TITLE
systemd: Drop deprecated cgroupv1 BlockIOWeight option

### DIFF
--- a/systemd/update-engine.service
+++ b/systemd/update-engine.service
@@ -7,7 +7,6 @@ ConditionPathExists=!/usr/.noupdate
 Type=dbus
 BusName=com.coreos.update1
 ExecStart=/usr/sbin/update_engine -foreground -logtostderr
-BlockIOWeight=100
 Restart=always
 RestartSec=30
 


### PR DESCRIPTION
It is deprecated since systemd v252.

Shows up as a warning during boot: `/usr/lib/systemd/system/update-engine.service:10: Support for option BlockIOWeight= has been removed and it is ignored`