### PR TITLE
Potential fix for code scanning alert no. 5: Suspicious add with sizeof

### DIFF
--- a/src/update_engine/utils_unittest.cc
+++ b/src/update_engine/utils_unittest.cc
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iterator>
 #include "strings/string_printf.h"
 #include "update_engine/test_utils.h"
 #include "update_engine/utils.h"
@@ -167,8 +168,7 @@ TEST(UtilsTest, FuzzIntTest) {
 
 TEST(UtilsTest, ApplyMapTest) {
   int initial_values[] = {1, 2, 3, 4, 6};
-  vector<int> collection(&initial_values[0],
-                         initial_values + arraysize(initial_values));
+  vector<int> collection(std::begin(initial_values), std::end(initial_values));
   EXPECT_EQ(arraysize(initial_values), collection.size());
   int expected_values[] = {1, 2, 5, 4, 8};
   map<int, int> value_map;


### PR DESCRIPTION
Potential fix for [https://github.com/flatcar/update_engine/security/code-scanning/5](https://github.com/flatcar/update_engine/security/code-scanning/5)

General fix: avoid pointer arithmetic with size-derived expressions in container range construction; use explicit begin/end helpers or indexing forms that clearly operate on elements.

Best fix here (without functional change): in `src/update_engine/utils_unittest.cc`, update the vector construction in `ApplyMapTest` to use `std::begin(initial_values)` and `std::end(initial_values)` instead of `&initial_values[0]` and `initial_values + arraysize(initial_values)`. This preserves exact behavior, improves readability, and removes the suspicious-offset pattern entirely.

Needed changes:
- Add `#include <iterator>` (for `std::begin`/`std::end`) near existing includes.
- Replace only the `vector<int> collection(...)` initialization lines in `ApplyMapTest`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
